### PR TITLE
Update Skein256.cpp

### DIFF
--- a/CEX/Skein256.cpp
+++ b/CEX/Skein256.cpp
@@ -312,7 +312,7 @@ void Skein256::Update(const std::vector<byte> &Input, size_t InOffset, size_t Le
 		}
 		else
 		{
-			if (m_msgLength != 0 && (m_msgLength + Length >= Skein::SKEIN256_RATE_SIZE))
+			if (m_msgLength != 0 && (m_msgLength + Length > Skein::SKEIN256_RATE_SIZE))
 			{
 				const size_t RMDLEN = Skein::SKEIN256_RATE_SIZE - m_msgLength;
 				if (RMDLEN != 0)


### PR DESCRIPTION
Update() function main overload worked incorrectly  in some cases.  When input data is processed by one byte chunks and m_msgBuffer is almost at its capacity but without last byte, this function will process m_msgBuffer and make it zero sized. This action will cause Finalize() function to work incorrectly beacause of the buffer being padded